### PR TITLE
[ceph] update add_cmd_output()

### DIFF
--- a/sos/plugins/ceph.py
+++ b/sos/plugins/ceph.py
@@ -42,12 +42,13 @@ class Ceph(Plugin, RedHatPlugin, UbuntuPlugin):
 
         self.add_cmd_output([
             "ceph status",
-            "ceph health",
+            "ceph health detail",
             "ceph osd tree",
             "ceph osd stat",
             "ceph osd dump",
             "ceph mon stat",
-            "ceph mon dump"
+            "ceph mon dump",
+            "ceph report"
         ])
 
         self.add_forbidden_path("/etc/ceph/*keyring")


### PR DESCRIPTION
add ceph report output
use "ceph health detail" instead of "ceph health"

Signed-off-by: Tyler Brekke <tbrekke@redhat.com>